### PR TITLE
Fixes windows build scripts not allowing spaces in file paths.

### DIFF
--- a/windows/cmake/build.cmd
+++ b/windows/cmake/build.cmd
@@ -7,12 +7,12 @@ rem Usage: build.cmd [arch] [build directory] [visual studio version]
 
 rem set paths
 SET BASEDIR=%CD%\..\..
-SET BUILDDIR=%2
+SET BUILDDIR=%~2
 SET MYDIR=%~dp0
 
-call %MYDIR%\..\config\toolchain.cmd
+call "%MYDIR%\..\config\toolchain.cmd"
 
-IF %TOOLCHAIN32% == "" (
+IF "%TOOLCHAIN32%" == "" (
   echo Toolchain not set
   GOTO END
 )
@@ -20,22 +20,22 @@ IF %TOOLCHAIN32% == "" (
 rem set Visual C++ build environment
 IF "%1" == "amd64" (
   echo Compiling for win64 using %TOOLCHAIN_NAME%
-  call %TOOLCHAIN64%
+  call "%TOOLCHAIN64%"
   SET INSTALLDIR=..\..\build\x64
 ) ELSE (
   IF "%1" == "arm" (
     echo Compiling for ARM using %TOOLCHAIN_NAME%
-    call %TOOLCHAINARM%
+    call "%TOOLCHAINARM%"
     SET INSTALLDIR=..\..\build\arm
   ) ELSE (
     echo Compiling for win32 using %TOOLCHAIN_NAME%
-    call %TOOLCHAIN32%
+    call "%TOOLCHAIN32%"
     SET INSTALLDIR=..\..\build
   )
 )
 
 rem go into the build directory
-CD "%BUILDDIR%"
+CD %BUILDDIR%
 nmake install
 
 :END

--- a/windows/cmake/generate.cmd
+++ b/windows/cmake/generate.cmd
@@ -10,9 +10,9 @@ SET MYDIR=%~dp0
 SET BASEDIR=%MYDIR%..\..
 SET BUILDARCH=%1
 SET PROJECT_TYPE=%2
-SET PROJECT_DIR=%3
-SET BUILDDIR=%4
-SET INSTALLDIR=%5
+SET PROJECT_DIR=%~3
+SET BUILDDIR=%~4
+SET INSTALLDIR=%~5
 SET BUILDTYPE=%6
 SET VSVERSION=%7
 SET BUILDSTATIC=%8
@@ -28,9 +28,9 @@ echo Build type = %BUILDTYPE%
 echo Visual Studio version = %VSVERSION%
 echo --------------------------------------
 
-call %MYDIR%..\config\toolchain.cmd
+call "%MYDIR%..\config\toolchain.cmd"
 
-IF %TOOLCHAIN32% == "" (
+IF "%TOOLCHAIN32%" == "" (
   echo Toolchain not set: %VSVERSION%
   pause
   GOTO END
@@ -39,16 +39,16 @@ IF %TOOLCHAIN32% == "" (
 rem set Visual C++ build environment
 IF "%BUILDARCH%" == "amd64" (
   echo Generating for win64 using %TOOLCHAIN_NAME%
-  call %TOOLCHAIN64%
+  call "%TOOLCHAIN64%"
   SET CMWAKE_WIN64=^-DWIN64^=1
 ) ELSE (
   IF "%BUILDARCH%" == "arm" (
     echo Generating for ARM using %TOOLCHAIN_NAME%
-    call %TOOLCHAINARM%
+    call "%TOOLCHAINARM%"
     SET CMWAKE_WIN64=^-DCMAKE_SYSTEM_NAME^=WindowsStore ^-DCMAKE_SYSTEM_VERSION^=10.0 
   ) ELSE (
     echo Generating for win32 using %TOOLCHAIN_NAME%
-    call %TOOLCHAIN32%
+    call "%TOOLCHAIN32%"
     SET CMWAKE_WIN64=^-DWIN32^=1
   )
 )
@@ -77,10 +77,10 @@ IF NOT EXIST "%BUILDDIR%" MKDIR "%BUILDDIR%"
 echo Generating project files for %GEN_PROJECT_TYPE% from %PROJECT_DIR% in %BUILDDIR%, installing to %INSTALLDIR%
 
 rem go into the build directory
-CD "%BUILDDIR%"
+CD %BUILDDIR%
 
 rem execute cmake to generate makefiles processable by nmake
-cmake %PROJECT_DIR% -G %GEN_PROJECT_TYPE% ^
+cmake "%PROJECT_DIR%" -G %GEN_PROJECT_TYPE% ^
       -DCMAKE_BUILD_TYPE=%BUILDTYPE% ^
       -DCMAKE_USER_MAKE_RULES_OVERRIDE="%MYDIR%c-flag-overrides.cmake" ^
       -DCMAKE_USER_MAKE_RULES_OVERRIDE_CXX="%MYDIR%cxx-flag-overrides.cmake" ^

--- a/windows/config/toolchain.cmd
+++ b/windows/config/toolchain.cmd
@@ -3,14 +3,33 @@ SET TOOLCHAIN32=""
 SET TOOLCHAIN64=""
 SET TOOLCHAINARM=""
 
+IF EXIST "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\Common7\Tools" (
+  SET "VS160COMNTOOLS=C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\Common7\Tools\"
+)
+IF EXIST "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\Common7\Tools" (
+  SET "VS160COMNTOOLS=C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\Common7\Tools\"
+)
+IF EXIST "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools" (
+  SET "VS160COMNTOOLS=C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\"
+)
+IF EXIST "C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\Common7\Tools" (
+  SET "VS160COMNTOOLS=C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\Common7\Tools\"
+)
+
+IF "%VSVERSION%" == "16" (
+  SET "TOOLCHAIN32=%VS160COMNTOOLS%..\..\VC\Auxiliary\Build\vcvars32.bat"
+  SET "TOOLCHAIN64=%VS160COMNTOOLS%..\..\VC\Auxiliary\Build\vcvars64.bat"
+  SET "TOOLCHAINARM=%VS160COMNTOOLS%..\..\VC\Auxiliary\Build\vcvarsx86_arm.bat"
+  SET TOOLCHAIN_NAME=Visual Studio 16 2019
+)
 IF "%VSVERSION%" == "14" (
-  SET TOOLCHAIN32="%VS140COMNTOOLS%..\..\VC\bin\vcvars32.bat"
-  SET TOOLCHAIN64="%VS140COMNTOOLS%..\..\VC\bin\amd64\vcvars64.bat"
-  SET TOOLCHAINARM="%VS140COMNTOOLS%..\..\VC\bin\x86_arm\vcvarsx86_arm.bat"
+  SET "TOOLCHAIN32=%VS140COMNTOOLS%..\..\VC\bin\vcvars32.bat"
+  SET "TOOLCHAIN64=%VS140COMNTOOLS%..\..\VC\bin\amd64\vcvars64.bat"
+  SET "TOOLCHAINARM=%VS140COMNTOOLS%..\..\VC\bin\x86_arm\vcvarsx86_arm.bat"
   SET TOOLCHAIN_NAME=Visual Studio 14 2015
 )
 IF "%VSVERSION%" == "12" (
-  SET TOOLCHAIN32="%VS120COMNTOOLS%..\..\VC\bin\vcvars32.bat"
-  SET TOOLCHAIN64="%VS120COMNTOOLS%..\..\VC\bin\amd64\vcvars64.bat"
+  SET "TOOLCHAIN32=%VS120COMNTOOLS%..\..\VC\bin\vcvars32.bat"
+  SET "TOOLCHAIN64=%VS120COMNTOOLS%..\..\VC\bin\amd64\vcvars64.bat"
   SET TOOLCHAIN_NAME=Visual Studio 12 2013
 )


### PR DESCRIPTION
This is to address Pulse-Eight/libcec#474. Since the affected batch scripts are split over submodules, I also submitted two other pull requests in Pulse-Eight/libcec and Pulse-Eight/platform.