### PR TITLE
Add support for building for Windows ARM64

### DIFF
--- a/windows/cmake/generate.cmd
+++ b/windows/cmake/generate.cmd
@@ -58,11 +58,19 @@ IF "%PROJECT_TYPE%" == "vs" (
         SET CMAKE_A_OPT=-A ARM
       )
     ) ELSE (
-      IF "%TOOLCHAIN_CMAKE_A_OPT%" == "" (
-        SET CMAKE_A_OPT=
+      IF "%BUILDARCH%" == "arm64" (
+         IF "%TOOLCHAIN_CMAKE_A_OPT%" == "" (
+           SET GEN_PROJECT_TYPE="%TOOLCHAIN_NAME% ARM64"
+         ) ELSE (
+           SET CMAKE_A_OPT=-A ARM64
+         )  
       ) ELSE (
-        SET CMAKE_A_OPT=-A Win32
-      )
+        IF "%TOOLCHAIN_CMAKE_A_OPT%" == "" (
+          SET CMAKE_A_OPT=
+        ) ELSE (
+          SET CMAKE_A_OPT=-A Win32
+        )
+      )   
     )
   )
 )

--- a/windows/config/toolchain.cmd
+++ b/windows/config/toolchain.cmd
@@ -50,14 +50,17 @@ IF "%VSVERSION%" == "2019" (
     SET TOOLCHAIN32="%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat"
     SET TOOLCHAIN64="%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat"
     SET TOOLCHAINARM="%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat"
+    SET TOOLCHAINARM64="%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat"
   ) ELSE (
     SET TOOLCHAIN32="%VS160COMNTOOLS%..\..\VC\Auxiliary\Build\vcvarsall.bat"
     SET TOOLCHAIN64="%VS160COMNTOOLS%..\..\VC\Auxiliary\Build\vcvarsall.bat"
     SET TOOLCHAINARM="%VS160COMNTOOLS%..\..\VC\Auxiliary\Build\vcvarsall.bat"
+    SET TOOLCHAINARM64="%VS160COMNTOOLS%..\..\VC\Auxiliary\Build\vcvarsall.bat"
   )
   SET TOOLCHAIN32CFG=x86
   SET TOOLCHAIN64CFG=amd64
   SET TOOLCHAINARMCFG=amd64_arm
+  SET TOOLCHAINARM64CFG=amd64_arm64
   SET TOOLCHAIN_NAME=Visual Studio 16 2019
   SET TOOLCHAIN_CMAKE_A_OPT=-A
 )
@@ -70,8 +73,8 @@ IF "%BUILDARCH%" == "amd64" (
   IF %errorlevel% neq 0 EXIT /b %errorlevel%
 ) ELSE (
   IF "%BUILDARCH%" == "arm64" (
-    SET CMWAKE_WIN64=^-D_M_ARM64 ^-DCMAKE_SYSTEM_VERSION^=10.0
-    CALL %TOOLCHAINARM% %TOOLCHAINARMCFG%
+    SET CMWAKE_WIN64=^-D_M_ARM64=1 ^-DCMAKE_SYSTEM_VERSION^=10.0
+    CALL %TOOLCHAINARM64% %TOOLCHAINARM64CFG%
     IF %errorlevel% neq 0 EXIT /b %errorlevel%
   ) ELSE (  
     IF "%BUILDARCH%" == "arm" (

--- a/windows/config/toolchain.cmd
+++ b/windows/config/toolchain.cmd
@@ -69,15 +69,21 @@ IF "%BUILDARCH%" == "amd64" (
   CALL %TOOLCHAIN64% %TOOLCHAIN64CFG%
   IF %errorlevel% neq 0 EXIT /b %errorlevel%
 ) ELSE (
-  IF "%BUILDARCH%" == "arm" (
-    SET CMWAKE_WIN64=^-DCMAKE_SYSTEM_NAME^=WindowsStore ^-DCMAKE_SYSTEM_VERSION^=10.0
+  IF "%BUILDARCH%" == "arm64" (
+    SET CMWAKE_WIN64=^-D_M_ARM64 ^-DCMAKE_SYSTEM_VERSION^=10.0
     CALL %TOOLCHAINARM% %TOOLCHAINARMCFG%
     IF %errorlevel% neq 0 EXIT /b %errorlevel%
-  ) ELSE (
-    SET CMWAKE_WIN64=^-DWIN32^=1
-    CALL %TOOLCHAIN32% %TOOLCHAIN32CFG%
-    IF %errorlevel% neq 0 EXIT /b %errorlevel%
-  )
+  ) ELSE (  
+    IF "%BUILDARCH%" == "arm" (
+      SET CMWAKE_WIN64=^-DCMAKE_SYSTEM_NAME^=WindowsStore ^-DCMAKE_SYSTEM_VERSION^=10.0
+      CALL %TOOLCHAINARM% %TOOLCHAINARMCFG%
+      IF %errorlevel% neq 0 EXIT /b %errorlevel%
+    ) ELSE (
+      SET CMWAKE_WIN64=^-DWIN32^=1
+      CALL %TOOLCHAIN32% %TOOLCHAIN32CFG%
+      IF %errorlevel% neq 0 EXIT /b %errorlevel%
+    )
+  )  
 )
 
 rem ===========================================================================


### PR DESCRIPTION
This PR adds changes for "support" submodule to support building libcec for Windows ARM64.
This is one of my 3 PRs which enable libcec to be built for Windows ARM64. 
There's also one for "platform" submodule as well as the main "libcec" repository.

https://github.com/Pulse-Eight/platform/pull/50
https://github.com/Pulse-Eight/libcec/pull/670